### PR TITLE
#343 Firefox select2 dropdown issue

### DIFF
--- a/src/dataloaderinterface/static/dataloaderinterface/js/common-forms.js
+++ b/src/dataloaderinterface/static/dataloaderinterface/js/common-forms.js
@@ -5,13 +5,15 @@
 function initializeSelect(select) {
     setTimeout(function () {
         select.each(function(index, selectElement) {
+            var parent = $(selectElement).parents('[role="dialog"]');
             $(selectElement).select2({
                 theme: "bootstrap",
                 containerCssClass : "input-sm",
                 dropdownAutoWidth: true,
                 width: 'auto',
                 allowClear: true,
-                placeholder: $(selectElement).attr('placeholder')
+                placeholder: $(selectElement).attr('placeholder'),
+                dropdownParent: (parent.length)? parent: $(document.body)
             });
         });
     });


### PR DESCRIPTION
Fixed issue on Firefox where select2 needs to know the parent container in order for the search to work.