### PR TITLE
[#347] Enable persistent snackbar messages

### DIFF
--- a/src/dataloaderinterface/static/dataloaderinterface/css/style.css
+++ b/src/dataloaderinterface/static/dataloaderinterface/css/style.css
@@ -1433,6 +1433,11 @@ textarea[name="sensor_notes"] {
     top: 10px;
 }
 
+#btn-upload-file {
+    margin-left: 10px;
+    align-self: center;
+}
+
 div.file-preview {
     height: auto;
     padding: 1em;

--- a/src/dataloaderinterface/static/dataloaderinterface/css/style.css
+++ b/src/dataloaderinterface/static/dataloaderinterface/css/style.css
@@ -1442,6 +1442,10 @@ div.file-preview .file-name {
     word-break: break-word;
 }
 
+#file-preview-default {
+    align-self: center;
+}
+
 i.file-icon {
     font-size: 30px;
     color: #66cbcb;

--- a/src/dataloaderinterface/static/dataloaderinterface/js/manage-sensors.js
+++ b/src/dataloaderinterface/static/dataloaderinterface/js/manage-sensors.js
@@ -391,16 +391,16 @@ $(document).ready(function () {
             contentType: false,
             processData: false
         }).done(function (response) {
-            console.log(response);
+            // console.log(response);
             snackbarMsg("Data was uploaded successfully!");
             uploadFileButton.prop("disabled", false);
         }).fail(function (error) {
             console.log(error);
             try {
-                snackbarMsg("Failed to upload data. " + error.responseJSON.error)
+                snackbarMsg("Failed to upload data. " + error.responseJSON.error, true)
             }
             catch (err) {
-                snackbarMsg("Failed to upload data.")
+                snackbarMsg("Failed to upload data.", true)
             }
 
             uploadFileButton.prop("disabled", true);

--- a/src/dataloaderinterface/static/dataloaderinterface/js/websdl-utils.js
+++ b/src/dataloaderinterface/static/dataloaderinterface/js/websdl-utils.js
@@ -39,13 +39,45 @@ $(document).on('click', ".menu-order li", function () {
     localStorage.setItem("UISortState", JSON.stringify(UISortState));
 });
 
-function snackbarMsg(message, duration = 3000) {
-    var snackbarContainer = document.querySelector('#clipboard-snackbar');
-    snackbarContainer.MaterialSnackbar.showSnackbar({
-        message: message,
-        timeout: duration
-    });
+// Displays a snack bar message
+function snackbarMsg(message, persistent = false) {
+    var snackbar = document.querySelector('#clipboard-snackbar');
+    if (!persistent) {
+        snackbar.MaterialSnackbar.showSnackbar({
+            message: message,
+        });
+    }
+    else {
+        snackbar.MaterialSnackbar.showSnackbar({
+            message: message,
+            actionHandler: function () {},  // Just needs a function reference
+            actionText: "Dismiss",
+            timeout: -1 // Makes it persistent
+        });
+    }
 }
+
+// Override to allow persistent messages
+MaterialSnackbar.prototype.displaySnackbar_ = function () {
+    this.element_.setAttribute('aria-hidden', 'true');
+    if (this.actionHandler_) {
+        this.actionElement_.textContent = this.actionText_;
+        this.actionElement_.addEventListener('click', this.actionHandler_);
+        this.setActionHidden_(false);
+    }
+    this.textElement_.textContent = this.message_;
+    this.element_.classList.add(this.cssClasses_.ACTIVE);
+    this.element_.setAttribute('aria-hidden', 'false');
+
+    if (this.timeout_ > -1) {
+        setTimeout(this.cleanup_.bind(this), this.timeout_);
+    }
+    else {
+        this.actionElement_.addEventListener('click', function () {
+            setTimeout(this.cleanup_.bind(this), 0);
+        }.bind(this));
+    }
+};
 
 // Taken from https://stackoverflow.com/questions/15900485/correct-way-to-convert-size-in-bytes-to-kb-mb-gb-in-javascript
 function formatBytes(bytes, decimals) {

--- a/src/dataloaderinterface/templates/dataloaderinterface/base.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/base.html
@@ -126,7 +126,7 @@
     {% block content %}{% endblock %}
     <div id="clipboard-snackbar" class="mdl-js-snackbar mdl-snackbar">
         <div class="mdl-snackbar__text"></div>
-        <button class="mdl-snackbar__action hidden" type="button"></button>
+        <button class="mdl-snackbar__action" type="button"></button>
     </div>
 </div>
 

--- a/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
@@ -185,8 +185,7 @@
                                             <span class="file-size small text-muted"></span>
                                         </span>
                                         <button class="mdl-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
-                                                id="btn-upload-file" type="button" disabled
-                                                style="margin-left: 10px; align-self: center;">
+                                                id="btn-upload-file" type="button" disabled>
                                             <i class="material-icons center-icon">cloud_upload</i> <span>Upload</span>
                                         </button>
                                     </div>

--- a/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
@@ -173,16 +173,20 @@
                                 </span>
 
                                 <div class="file-preview grid">
-                                    <small id="file-preview-default" class="text-muted" style="align-self: center;">
+                                    <small id="file-preview-default" class="text-muted">
                                         No file chosen.
                                     </small>
                                     <div class="selected-file flex"
-                                         style="display:none; grid-template-columns: 30px 1fr 150px;">
+                                         style="display:none;">
                                         <i style="align-self: center;" class="fa fa-file-o file-icon"
                                            aria-hidden="true"></i>
-                                        <span style="align-self: center;"><span class="file-name">File name.csv</span><span class="file-size small text-muted"></span></span>
+                                        <span style="align-self: center;">
+                                            <span class="file-name">File name.csv</span>
+                                            <span class="file-size small text-muted"></span>
+                                        </span>
                                         <button class="mdl-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
-                                                id="btn-upload-file" type="button" disabled style="margin-left: 10px; align-self: center;">
+                                                id="btn-upload-file" type="button" disabled
+                                                style="margin-left: 10px; align-self: center;">
                                             <i class="material-icons center-icon">cloud_upload</i> <span>Upload</span>
                                         </button>
                                     </div>

--- a/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/manage_sensors.html
@@ -176,13 +176,13 @@
                                     <small id="file-preview-default" class="text-muted" style="align-self: center;">
                                         No file chosen.
                                     </small>
-                                    <div class="selected-file grid"
+                                    <div class="selected-file flex"
                                          style="display:none; grid-template-columns: 30px 1fr 150px;">
                                         <i style="align-self: center;" class="fa fa-file-o file-icon"
                                            aria-hidden="true"></i>
                                         <span style="align-self: center;"><span class="file-name">File name.csv</span><span class="file-size small text-muted"></span></span>
                                         <button class="mdl-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
-                                                id="btn-upload-file" type="button" disabled style="margin: 0; align-self: center;">
+                                                id="btn-upload-file" type="button" disabled style="margin-left: 10px; align-self: center;">
                                             <i class="material-icons center-icon">cloud_upload</i> <span>Upload</span>
                                         </button>
                                     </div>


### PR DESCRIPTION
The error message while uploading data files will now stay on the page until dismissed.
![image](https://user-images.githubusercontent.com/2448568/50357156-3350e300-0512-11e9-8ac2-71fb90fd9e52.png)


Also contains minor layout adjustments