### PR TITLE
Removing influx db dependency

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebSDL.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "WebSDL.settings.development")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
### Related Issues
#510 
#522 

### Problem
The replaced of InfluxDB with TimeScaleDB cause the auto generation of the primary key field (resultid) for the timeseriesresultvalues table stopped working. This also caused the API methods (which contain models depended on this auto generation) to stop working. 

### Solution
A work around class was implemented to restore the ability to INSERT data into timeseriesresultvalues table. The class uses a direct parameterized INSERT query as opposed to the Django models classes (used by the rest of the application). Longer term, additional work is needed to provide a more consistent set of back end data models, but this approach will still allow us to bring that application into production, while we continue to work on a better data model solution.  

### Testing
Testing for the api/data-stream/ method was conducted via post requests using [Postman](https://www.postman.com/). For the csv upload function manually testing was conducted because there is presently no method to authenticate a user via the API outside of a request made from the application. Additional testing using a real sensor to push data to the staging server should be conducted.

   