### PR TITLE
Fix Issue #523

### DIFF
--- a/src/dataloaderinterface/static/timeseries_visualization/js/visualization.js
+++ b/src/dataloaderinterface/static/timeseries_visualization/js/visualization.js
@@ -91,9 +91,9 @@ function displayMessage(title, msg) {
 
 function dateToString(date) {
 	if (date !== null && date !== undefined) {
-		year = date.getFullYear();
-		month = date.getMonth() + 1;
-		day =  date.getDate();
+		year = date.getUTCFullYear();
+		month = date.getUTCMonth() + 1;
+		day =  date.getUTCDate();
 		return `${year}-${month}-${day}`;
 	}	
 	return '';


### PR DESCRIPTION
See issue for additional detail #523. Clicking the 'Update Plot' button would cause the selected datetime values to shift by 1 day. This was caused by a UTC issue in which the date was converted to UTC equivalent. The year, month, and day of that date are later used to repopulate the date picker values, but because of the UTC shift in the US the date would be one day sooner than the original selected value. 