### PR TITLE
Fix LeafPack Sites not rendering

### DIFF
--- a/src/leafpack/models.py
+++ b/src/leafpack/models.py
@@ -7,6 +7,7 @@ from accounts.models import User
 from django.db.models import Sum, Q
 from operator import __or__ as OR
 
+from functools import reduce
 
 class Macroinvertebrate(models.Model):
     """


### PR DESCRIPTION
Relates to #381.
This is related to a change between python 2.7 and 3.7+ which was missed during the initial conversion.