### PR TITLE
Fix leafpack 500 error

### DIFF
--- a/src/leafpack/csv_writer.py
+++ b/src/leafpack/csv_writer.py
@@ -52,7 +52,7 @@ class LeafPackCSVWriter(object):
 
         # write leafpack data
         self.make_header(['Leaf Pack Details'])
-        for key, value in data.iteritems():
+        for key, value in data.items():
             self.writer.writerow([key.title(), value])
         self.writerow(['URL', '{0}/sites/{1}/{2}'.format(self.HYPERLINK_BASE_URL,
                                                          site_registration.sampling_feature_code,

--- a/src/leafpack/views.py
+++ b/src/leafpack/views.py
@@ -45,7 +45,7 @@ class LeafPackFormMixin(object):
     def get_bug_count_forms(self, leafpack=None):
         re_bug_name = re.compile(r'^(?P<bug_name>.*)-bug_count')
         form_data = list()
-        for key, value in self.request.POST.iteritems():
+        for key, value in self.request.POST.items():
             if 'bug_count' in key:
                 form_data.append((re_bug_name.findall(key)[0], value))
 


### PR DESCRIPTION
Addressed #557 

There was a missed update between in the conversion from python 2.7 to python 3.8. Dictionary object calls to iteritems are no longer supported in Python 3+ and the items method should be used in its place.