### PR TITLE
Revised approach to sync dataloader_sensormeasurement table

### DIFF
--- a/src/dataloaderservices/views.py
+++ b/src/dataloaderservices/views.py
@@ -319,8 +319,7 @@ class SensorDataUploadView(APIView):
                 continue
             last_data_value = row[results_mapping['results'][uuid]['index']]
             last_measurement = SensorMeasurement.objects.filter(sensor=sensor).first()
-            if not last_measurement or last_measurement and last_measurement.value_datetime < measurement_datetime:
-                last_measurement and last_measurement.delete()
+            if not last_measurement:
                 SensorMeasurement.objects.create(
                     sensor=sensor,
                     value_datetime=measurement_datetime,
@@ -699,35 +698,29 @@ def get_site_sensor(resultid:str) -> Union[Dict[str, Any],None]:
         return df.to_dict(orient='records')[0]
 
 #dataloader utility function
-def update_sensormeasurement(sensor_id:str, result_value:TimeseriesResultValueTechDebt) -> None:
+def check_sensormeasurement(sensor_id:str, result_value:TimeseriesResultValueTechDebt) -> None:
     with _db_engine.connect() as connection:
-        query = text('UPDATE public.dataloaderinterface_sensormeasurement ' \
-            "SET value_datetime=:datetime, " \
-            "value_datetime_utc_offset = :utc_offset, " \
-            'data_value = :data_value ' \
+        query = text('SELECT COUNT(sensor_id) FROM public.dataloaderinterface_sensormeasurement ' \
             'WHERE sensor_id=:sensor_id; ')
         result = connection.execute(query, 
-            sensor_id=sensor_id,
-            datetime=result_value.value_datetime, 
-            utc_offset=timedelta(hours=result_value.utc_offset),
-            data_value=result_value.data_value
+            sensor_id=sensor_id
             ) 
-        if result.rowcount < 1:
-            query = text('INSERT INTO dataloaderinterface_sensormeasurement ' \
-                "VALUES (:sensor_id,:datetime,':utc_offset',:data_value); ")
+        for r in result:
+            if r[0] == 1: return None
+            query = text('INSERT INTO public.dataloaderinterface_sensormeasurement ' \
+                "VALUES (:sensor_id, :datetime,:utc_offset,:data_value); ")
             result = connection.execute(query, 
                 sensor_id=sensor_id,
                 datetime=result_value.value_datetime, 
                 utc_offset=timedelta(hours=result_value.utc_offset),
                 data_value=result_value.data_value
-            ) 
-    return result
+            )
 
 #dataloader utility function
 def sync_dataloader_tables(result_value: TimeseriesResultValueTechDebt) -> None:
     site_sensor = get_site_sensor(result_value.result_id)
     if not site_sensor: return None
-    result = update_sensormeasurement(site_sensor['id'], result_value)
+    result = check_sensormeasurement(site_sensor['id'], result_value)
     return None
 
 #dataloader utility function


### PR DESCRIPTION
Related to #560
This revises how the API data stream keeps the dataloader table in sync. The logic has been simplified to only create new records in the dataloader_sensormeasurement table when one does not exist. Separately a database function have been created to keep the sensormeasure table in sync and in triggered whenever data is inserted into the timeseriesresultvalues table.