### PR TITLE
Hotfix for Deleting sites with data

### DIFF
--- a/src/dataloader/models.py
+++ b/src/dataloader/models.py
@@ -104,7 +104,7 @@ class ObjectRelation(models.Model):
 
 @python_2_unicode_compatible
 class ExtendedResult(models.Model):
-    result = models.OneToOneField('Result', db_column='resultid', on_delete=models.CASCADE, primary_key=True)
+    result = models.OneToOneField('Result', db_column='resultid', on_delete=models.DO_NOTHING, primary_key=True)
     spatial_reference = models.ForeignKey('SpatialReference', db_column='spatialreferenceid', on_delete=models.CASCADE, blank=True, null=True)
 
     def __str__(self):
@@ -1997,7 +1997,7 @@ class SpectraResultValue(ResultValue, QualityControlComponent, TimeAggregationCo
 
 
 class TimeSeriesResultValue(ResultValue, QualityControlComponent, TimeAggregationComponent):
-    result = models.ForeignKey('TimeSeriesResult', related_name='values', db_column='resultid', on_delete=models.CASCADE)
+    result = models.ForeignKey('TimeSeriesResult', related_name='values', db_column='resultid', on_delete=models.DO_NOTHING)
     data_value = models.FloatField(db_column='datavalue')
     annotations = models.ManyToManyField('Annotation', related_name='annotated_time_series_values',
                                          through='TimeSeriesResultValueAnnotation')


### PR DESCRIPTION
Related to #574
Due to compression of the timeseriesresultvalues datatable, the command for deleting a site and cascading through various table fails when it arrives at the timeseriesresultvalues table, preventing the site from being deleting. This hot fix solution modifies the constraint so that on delete for timeseriesresultvalues will not cascade. This will result in orphaned timeseriesresultvalues in the database, so this solution is not ideal. Additional work is needed in the near future to develop methods for decompressing the tables and deleting the timeseriesresultvalues in cascade.