### PR TITLE
Add Auxiliary Method In ODM2 Data models

### DIFF
--- a/src/odm2/__init__.py
+++ b/src/odm2/__init__.py
@@ -1,11 +1,10 @@
-from odm2 import base as _base
-import pickle as _pickle
-import odm2.models as models 
+from odm2.base import ODM2DataModels
+from django.conf import settings
+import sqlalchemy
 
-engine = _base.engine
-Session = _base.Session
+_dbsettings = settings.DATABASES['default']
+_connection_str = f"postgresql://{_dbsettings['USER']}:{_dbsettings['PASSWORD']}@{_dbsettings['HOST']}:{_dbsettings['PORT']}/{_dbsettings['NAME']}"
+_engine = sqlalchemy.create_engine(_connection_str, pool_size=10)
+_cache_path = settings.DATAMODELCACHE
 
-if not _base.cached:
-	_base._model_base.prepare(engine)
-	with open(_base.cache_path, 'wb') as file:
-		_pickle.dump(_base._model_base.metadata, file)
+odm2datamodels = ODM2DataModels(_engine, _cache_path)

--- a/src/odm2/__init__.py
+++ b/src/odm2/__init__.py
@@ -7,4 +7,4 @@ _connection_str = f"postgresql://{_dbsettings['USER']}:{_dbsettings['PASSWORD']}
 _engine = sqlalchemy.create_engine(_connection_str, pool_size=10)
 _cache_path = settings.DATAMODELCACHE
 
-odm2datamodels = ODM2DataModels(_engine, _cache_path)
+odm2datamodels = ODM2DataModels(_engine, cache_path=_cache_path)

--- a/src/odm2/base.py
+++ b/src/odm2/base.py
@@ -1,17 +1,30 @@
 import sqlalchemy
+from sqlalchemy.sql.expression import Select
+from sqlalchemy.orm import Query    
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.ext.declarative import declared_attr, declarative_base
 
 import pickle
+from typing import Dict, Union, Any, Type, List
+import warnings
 
-from django.conf import settings
+import pandas as pd
 
-_dbsettings = settings.DATABASES['default']
-_connection_str = f"postgresql://{_dbsettings['USER']}:{_dbsettings['PASSWORD']}@{_dbsettings['HOST']}:{_dbsettings['PORT']}/{_dbsettings['NAME']}"
-engine = sqlalchemy.create_engine(_connection_str, pool_size=10)
-Session = sqlalchemy.orm.sessionmaker(engine)
+from .exceptions import ObjectNotFound
+from .models import annotations
+from .models import core
+from .models import cv
+from .models import dataquality
+from .models import equipment
+from .models import extensionproperties
+from .models import externalidentifiers
+from .models import labanalyses
+from .models import provenance
+from .models import results
+from .models import samplingfeatures
+from .models import simulation
 
-cache_path = settings.DATAMODELCACHE
+OUTPUT_FORMATS = ('json', 'dataframe', 'dict')
 
 class Base():
     
@@ -20,8 +33,223 @@ class Base():
         cls_name = str(self.__name__)
         return cls_name.lower()
 
-_model_base = None
-cached = None
+    @classmethod
+    def from_dict(cls, attributes_dict:Dict) -> object:
+        """Alternative constructor that uses dictionary to populate attributes"""
+        instance = cls.__new__(cls)
+        instance.__init__()
+        for key, value in attributes_dict.items():
+            if hasattr(instance, key):
+                if value == '': value = None
+                setattr(instance, key, value)
+        return instance
+
+    def to_dict(self) -> Dict[str,Any]:
+        """Converts attributes into a dictionary"""
+        columns = self.__table__.columns.keys()
+        output_dict = {}
+        for column in columns:
+            output_dict[column] = getattr(self,column)
+        return output_dict
+    
+    def update_from_dict(self, attributes_dict:Dict[str, any]) -> None:
+        """Updates instance attributes based on provided dictionary"""
+        for key, value in attributes_dict.items():
+            if hasattr(self, key):
+                if value == '': value = None
+                setattr(self, key, value)
+
+    @classmethod
+    def get_pkey_name(cls) -> Union[str,None]:
+        """ Returns the primary key field name for a given model"""
+        columns = cls.__table__.columns
+        for column in columns:
+            if column.primary_key: return column.name 
+        return None
+
+class ODM2Engine:
+
+    def __init__(self, session_maker:sqlalchemy.orm.sessionmaker) -> None:
+        self.session_maker = session_maker
+
+    def read_query(self, 
+            query: Union[Query, Select],
+            output_format:str='json',
+            orient:str='records') -> Union[str, pd.DataFrame]:
+
+        # guard against invalid output_format strings
+        if output_format not in OUTPUT_FORMATS:
+            raise ValueError(f':argument output_format={output_format}, is not a valid output_format strings: {OUTPUT_FORMATS}')
+        
+        # use SQLAlchemy session to read_query and return response in the designated output_format
+        with self.session_maker() as session:
+            if isinstance(query, Select):
+                df = pd.read_sql(query, session.bind)
+            else:
+                df = pd.read_sql(query.statement, session.bind)
+            
+            if output_format == 'json':
+                return df.to_json(orient=orient)
+            elif output_format == 'dataframe':
+                return df
+            elif output_format == 'dict':
+                return df.to_dict()
+            raise TypeError("Unknown output format")
+
+    def insert_query(self, objs:List[object]) -> None:
+        with self.session_maker() as session:
+            session.add_all(objs)
+            session.commit()
+
+    def create_object(self, obj:object, perserve_pkey:bool=False) -> Union[int, str]:
+        """ Accepts an ORM mapped model and created a corresponding database record
+
+        Accepts on one of the ORM mapped models and creates the corresponding database 
+        record, returning the primary key of the newly created record.
+
+        Arguments:
+            obj:object - The ORM mapped model
+            preserve_pkey:bool - Default=False - flag indicating if the primary key for 
+                the object should be preserved. Avoid in general use cases where database has 
+                a serial that auto assigned primary key, however this can be set to True to
+                specify you own the primary key value.  
+
+        Returns:
+            primary key: Union[int, str]        
+
+        """
+        
+        if not perserve_pkey:
+            pkey_name = obj.get_pkey_name()
+            setattr(obj, pkey_name, None)
+
+        with self.session_maker() as session:
+            session.add(obj)
+            session.commit()
+            pkey_value = getattr(obj, pkey_name)
+            return pkey_value
+
+    def read_object(self, model:Type[Base], pkey:Union[int, str], 
+            output_format:str='dict', 
+            orient:str='records') -> Dict[str, Any]:
+
+        with self.session_maker() as session:
+            obj = session.get(model, pkey)
+            pkey_name = model.get_pkey_name()
+            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            session.commit()
+
+            # convert obj_dict to a dictionary if it isn't one already
+            obj_dict = obj.to_dict()
+
+            # guard against invalid output_format strings
+            if output_format not in OUTPUT_FORMATS:
+                raise ValueError(f':param output_format = {output_format}, which is not one of the following valid output_format strings: {OUTPUT_FORMATS}')
+
+            if output_format == 'dict':
+                return obj_dict
+
+            else:
+                # convert to series if only one row
+                keys = list(obj_dict.keys())
+                if not isinstance(obj_dict[keys[0]], list):
+                    for key in keys:
+                        new_value = [obj_dict[key]]
+                        obj_dict[key] = new_value
+
+                obj_df = pd.DataFrame.from_dict(obj_dict)
+                if output_format == 'dataframe':
+                    return obj_df
+                elif output_format == 'json':
+                    return obj_df.to_json(orient=orient)
+                raise TypeError("Unknown output format")
+
+    def update_object(self, model:Type[Base], pkey:Union[int,str], data:Dict[str, Any]) -> None:
+        if not isinstance(data, dict):
+            data = data.dict()
+        pkey_name = model.get_pkey_name()
+        if pkey_name in data:
+            data.pop(pkey_name)
+        with self.session_maker() as session:
+            obj = session.get(model, pkey)
+            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            obj.update_from_dict(data)
+            session.commit()
+
+    def delete_object(self, model:Type[Base], pkey:Union[int, str]) -> None:
+        with self.session_maker() as session:
+            obj = session.get(model, pkey)
+            pkey_name = model.get_pkey_name()
+            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            session.delete(obj)
+            session.commit()
+
+class Models:
+
+    def __init__(self, base_model) -> None:
+        self._base_model = base_model
+        self._process_schema(annotations)        
+        self._process_schema(core)        
+        self._process_schema(cv)        
+        self._process_schema(dataquality)        
+        self._process_schema(equipment)        
+        self._process_schema(extensionproperties)        
+        self._process_schema(externalidentifiers)        
+        self._process_schema(labanalyses)        
+        self._process_schema(provenance)        
+        self._process_schema(results)        
+        self._process_schema(samplingfeatures)        
+        self._process_schema(simulation)         
+
+    def _process_schema(self, schema:str) -> None:
+        classes = [c for c in dir(schema) if not c.startswith('__')]
+        base = tuple([self._base_model])
+        for class_name in classes:
+            model = getattr(schema, class_name)
+            model_attribs = self._trim_dunders(dict(model.__dict__.copy())) 
+            extended_model =  type(class_name, base, model_attribs) 
+            setattr(self, class_name, extended_model)
+
+    def _trim_dunders(self, dictionary:Dict[str, Any]) -> Dict[str, Any]:
+        return { k:v for k, v in dictionary.items() if not k.startswith('__') } 
+
+class ODM2DataModels():
+
+    def __init__(self, engine:sqlalchemy.engine, schema:str='odm2', cache_path:str=None) -> None:
+
+        self._schema = schema
+        self._cache_path = cache_path
+
+        self._engine = engine
+        self._session = sqlalchemy.orm.sessionmaker(self._engine)
+        self._cached= False
+        self.odm2_engine: ODM2Engine = ODM2Engine(self._session)
+
+        self._model_base = self._prepare_model_base()
+        self.models = Models(self._model_base)
+        if not self._cached:
+            self._prepare_automap_models()
+
+    def _prepare_model_base(self):
+        try:
+            with open(self._cache_path, 'rb') as file:
+                metadata = pickle.load(file=file)
+                self._cached = True
+                return declarative_base(cls=Base, bind=self._engine, metadata=metadata)
+        except FileNotFoundError: 
+            metadata = sqlalchemy.MetaData(schema=self._schema)
+            self._cached = False
+            return automap_base(cls=Base, metadata=metadata)
+
+    def _prepare_automap_models(self):
+        self._model_base.prepare(self._engine)
+        if not self._cache_path: return
+        try:
+            with open(self._cache_path, 'wb') as file:
+                pickle.dump(self._model_base.metadata, file)
+        except FileNotFoundError:
+            warnings.warn('Unable to cache models which may lead to degraded performance.', RuntimeWarning)
+
 try:
     with open(cache_path, 'rb') as file:
         metadata = pickle.load(file=file)

--- a/src/odm2/exceptions.py
+++ b/src/odm2/exceptions.py
@@ -1,0 +1,6 @@
+class ObjectNotFound(Exception):
+
+    def __init__(self, message:str) -> None:
+        self.message = message
+        super().__init__()
+

--- a/src/odm2/models/annotations.py
+++ b/src/odm2/models/annotations.py
@@ -1,48 +1,45 @@
-from odm2.base import _model_base as _model_base
-
-
 """Data models corresponding to the tables under the ODM2Annotations schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Annotations.html
 """
 
-class ActionAnnotations(_model_base):
+class ActionAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_ActionAnnotations.html"""
 
-class Annotations(_model_base):
+class Annotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_Annotations.html"""
 
-class CategoricalResultValueAnnotations(_model_base):
+class CategoricalResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_CategoricalResultValueAnnotations.html"""
 
-class EquipmentAnnotations(_model_base):
+class EquipmentAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_EquipmentAnnotations.html"""
 
-class MethodAnnotations(_model_base):
+class MethodAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_MethodAnnotations.html"""
 
-class PointCoverageResultValueAnnotations(_model_base):
+class PointCoverageResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_PointCoverageEesultValueAnnotations.html"""
 
-class ProfileResultValueAnnotations(_model_base):
+class ProfileResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_ProfileResultValueAnnotations.html"""
 
-class ResultAnnotations(_model_base):
+class ResultAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_ResultAnnotations.html"""
 
-class SamplingFeatureAnnotations(_model_base):
+class SamplingFeatureAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_SamplingFeatureAnnotations.html"""
 
-class SectionResultValueAnnotations(_model_base):
+class SectionResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_SectionResultValueAnnotations.html"""
 
-class SpectraResultValueAnnotations(_model_base):
+class SpectraResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_SpectraResultValueAnnotations.html"""
 
-class TimeSeriesResultValueAnnotations(_model_base):
+class TimeSeriesResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_TimeSeriesResultValueAnnotations.html"""
 
-class TrajectoryResultValueAnnotations(_model_base):
+class TrajectoryResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_TrajectoryResultValueAnnotations.html"""
 
-class TransectResultValueAnnotations(_model_base):
+class TransectResultValueAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Annotations_TransectResultValueAnnotations.html"""

--- a/src/odm2/models/core.py
+++ b/src/odm2/models/core.py
@@ -1,53 +1,51 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Core schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Core.html
 """
 
-class ActionBy(_model_base):
+class ActionBy():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_ActionBy.html"""
 
-class Actions(_model_base):
+class Actions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Actions.html"""
 
-class Affiliations(_model_base):
+class Affiliations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Affiliations.html"""
 
-class Datasets(_model_base):
+class Datasets():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Datasets.html"""
 
-class DatasetsResults(_model_base):
+class DatasetsResults():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_DatasetsResults.html"""
 
-class FeatureActions(_model_base):
+class FeatureActions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_FeatureActions.html"""
 
-class Methods(_model_base):
+class Methods():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Methods.html"""
 
-class Organizations(_model_base):
+class Organizations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Organizations.html"""
 
-class People(_model_base):
+class People():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_People.html"""
 
-class ProcessingLevels(_model_base):
+class ProcessingLevels():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_ProcessingLevels.html"""
 
-class RelatedActions(_model_base):
+class RelatedActions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_RelatedActions.html"""
 
-class Results(_model_base):
+class Results():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Results.html"""
 
-class SamplingFeatures(_model_base):
+class SamplingFeatures():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_SamplingFeatures.html"""
 
-class TaxonomicClassifiers(_model_base):
+class TaxonomicClassifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_TaxonomicClassifiers.html"""
 
-class Units(_model_base):
+class Units():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Units.html"""
 
-class Variables(_model_base):
+class Variables():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Core_Variables.html"""

--- a/src/odm2/models/cv.py
+++ b/src/odm2/models/cv.py
@@ -1,86 +1,84 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2CV schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2CV.html
 """
 
-class CV_ActionType(_model_base):
+class CV_ActionType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_ActionType.html"""
 
-class CV_AggregationStatistic(_model_base):
+class CV_AggregationStatistic():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_AggregationStatistic.html"""
 
-class CV_AnnotationType(_model_base):
+class CV_AnnotationType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_AnnotationType.html"""
 
-class CV_CensorCode(_model_base):
+class CV_CensorCode():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_CensorCode.html"""
 
-class CV_DataQualityType(_model_base):
+class CV_DataQualityType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_DataQualityType.html"""
 
-class CV_DatasetType(_model_base):
+class CV_DatasetType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_DatasetType.html"""
 
-class CV_DirectiveType(_model_base):
+class CV_DirectiveType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_DirectiveType.html"""
 
-class CV_ElevationDatum(_model_base):
+class CV_ElevationDatum():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_ElevationDatum.html"""
 
-class CV_EquipmentType(_model_base):
+class CV_EquipmentType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_EquipmentType.html"""
 
-class CV_Medium(_model_base):
+class CV_Medium():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_Medium.html"""
 
-class CV_MethodType(_model_base):
+class CV_MethodType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_MethodType.html"""
 
-class CV_OrganizationType(_model_base):
+class CV_OrganizationType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_OrganizationType.html"""
 
-class CV_PropertyDataType(_model_base):
+class CV_PropertyDataType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_PropertyDataType.html"""
 
-class CV_QualityCode(_model_base):
+class CV_QualityCode():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_QualityCode.html"""
 
-class CV_RelationshipType(_model_base):
+class CV_RelationshipType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_RelationshipType.html"""
 
-class CV_ResultType(_model_base):
+class CV_ResultType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_ResultType.html"""
 
-class CV_SamplingFeatureGeoType(_model_base):
+class CV_SamplingFeatureGeoType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_SamplingFeatureGeoType.html"""
 
-class CV_SamplingFeatureType(_model_base):
+class CV_SamplingFeatureType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_SamplingFeatureType.html"""
 
-class CV_SiteType(_model_base):
+class CV_SiteType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_SiteType.html"""
 
-class CV_SpatialOffsetType(_model_base):
+class CV_SpatialOffsetType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_SpatialOffsetType.html"""
 
-class CV_Speciation(_model_base):
+class CV_Speciation():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_Speciation.html"""
 
-class CV_SpecimenType(_model_base):
+class CV_SpecimenType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_SpecimenType.html"""
 
-class CV_Status(_model_base):
+class CV_Status():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_Status.html"""
 
-class CV_TaxonomicClassifierType(_model_base):
+class CV_TaxonomicClassifierType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_TaxonomicClassifierType.html"""
 
-class CV_UnitsType(_model_base):
+class CV_UnitsType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_UnitsType.html"""
 
-class CV_VariableName(_model_base):
+class CV_VariableName():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_VariableName.html"""
 
-class CV_VariableType(_model_base):
+class CV_VariableType():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2CV_CV_VariableType.html"""

--- a/src/odm2/models/dataquality.py
+++ b/src/odm2/models/dataquality.py
@@ -1,20 +1,18 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2DataQuality schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2DataQuality.html
 """
 
-class DataQuality(_model_base):
+class DataQuality():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2DataQuality_DataQuality.html"""
 
-class ReferenceMaterials(_model_base):
+class ReferenceMaterials():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2DataQuality_ReferenceMaterials.html"""
 
-class ReferenceMaterialValues(_model_base):
+class ReferenceMaterialValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2DataQuality_ReferenceMaterialValues.html"""
 
-class ResultNormalizationValues(_model_base):
+class ResultNormalizationValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2DataQuality_ResultNormalizationValues.html"""
 
-class ResultsDataQuality(_model_base):
+class ResultsDataQuality():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2DataQuality_ResultsDataQuality.html"""

--- a/src/odm2/models/equipment.py
+++ b/src/odm2/models/equipment.py
@@ -1,41 +1,39 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Equipment schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Equipment.html
 """
 
-class CalibrationActions(_model_base):
+class CalibrationActions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_CalibrationActions.html"""
 
-class CalibrationReferenceEquipment(_model_base):
+class CalibrationReferenceEquipment():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_CalibrationReferenceEquipment.html"""
 
-class CalibrationStandards(_model_base):
+class CalibrationStandards():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_CalibrationStandards.html"""
 
-class DataloggerFileColumns(_model_base):
+class DataloggerFileColumns():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_DataloggerFileColumns.html"""
 
-class DataLoggerFiles(_model_base):
+class DataLoggerFiles():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_DataLoggerFiles.html"""
 
-class DataLoggerProgramFiles(_model_base):
+class DataLoggerProgramFiles():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_DataloggerProgramFiles.html"""
 
-class Equipment(_model_base):
+class Equipment():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_Equipment.html"""
 
-class EquipmentModels(_model_base):
+class EquipmentModels():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_EquipmentModels.html"""
 
-class EquipmentUsed(_model_base):
+class EquipmentUsed():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_EquipmentUsed.html"""
 
-class InstrumentOutputVariables(_model_base):
+class InstrumentOutputVariables():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_InstrumentOutputVariables.html"""
 
-class MaintenanceActions(_model_base):
+class MaintenanceActions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_MaintenanceActions.html"""
 
-class RelatedEquipment(_model_base):
+class RelatedEquipment():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Equipment_RelatedEquipment.html"""

--- a/src/odm2/models/extensionproperties.py
+++ b/src/odm2/models/extensionproperties.py
@@ -1,26 +1,24 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2ExtensionProperties schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2ExtensionProperties.html
 """
 
-class ActionExtensionPropertyValues(_model_base):
+class ActionExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_ActionExtensionPropertyValues.html"""
 
-class CitationExtensionPropertyValues(_model_base):
+class CitationExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_CitationExtensionPropertyValues.html"""
 
-class ExtensionProperties(_model_base):
+class ExtensionProperties():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_ExtensionProperties.html"""
 
-class MethodExtensionPropertyValues(_model_base):
+class MethodExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_MethodExtensionPropertyValues.html"""
 
-class ResultExtensionPropertyValues(_model_base):
+class ResultExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_ResultExtensionPropertyValues.html"""
 
-class SamplingFeatureExtensionPropertyValues(_model_base):
+class SamplingFeatureExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_SamplingFeatureExtensionPropertyValues.html"""
 
-class VariableExtensionPropertyValues(_model_base):
+class VariableExtensionPropertyValues():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExtensionProperties_VariableExtensionPropertyValues.html"""

--- a/src/odm2/models/externalidentifiers.py
+++ b/src/odm2/models/externalidentifiers.py
@@ -1,32 +1,30 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Core schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2ExternalIdentifiers.html
 """
 
-class CitationExternalIdentifiers(_model_base):
+class CitationExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_CitationExternalIdentifiers.html"""
 
-class ExternalIdentifierSystems(_model_base):
+class ExternalIdentifierSystems():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_ExternalIdentifierSystems.html"""
 
-class MethodExternalIdentifiers(_model_base):
+class MethodExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_MethodExternalIdentifiers.html"""
 
-class PersonExternalIdentifiers(_model_base):
+class PersonExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_PersonExternalIdentifiers.html"""
 
-class ReferenceMaterialExternalIdentifiers(_model_base):
+class ReferenceMaterialExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_ReferenceMaterialExternalIdentifiers.html"""
 
-class SamplingFeatureExternalIdentifiers(_model_base):
+class SamplingFeatureExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_SamplingFeatureExternalIdentifiers.html"""
 
-class SpatialReferenceExternalIdentifiers(_model_base):
+class SpatialReferenceExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_SpatialReferenceExternalIdentifiers.html"""
 
-class TaxonomicClassifierExternalIdentifiers(_model_base):
+class TaxonomicClassifierExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_TaxonomicClassifierExternalIdentifiers.html"""
 
-class VariableExternalIdentifiers(_model_base):
+class VariableExternalIdentifiers():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2ExternalIdentifiers_VariableExternalIdentifiers.html"""

--- a/src/odm2/models/labanalyses.py
+++ b/src/odm2/models/labanalyses.py
@@ -1,14 +1,12 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2LabAnalyses schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2LabAnalyses.html
 """
 
-class ActionDirectives(_model_base):
+class ActionDirectives():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2LabAnalyses_ActionDirectives.html"""
 
-class Directives(_model_base):
+class Directives():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2LabAnalyses_Directives.html"""
 
-class SpecimenBatchPositions(_model_base):
+class SpecimenBatchPositions():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2LabAnalyses_SpecimenBatchPostions.html"""

--- a/src/odm2/models/provenance.py
+++ b/src/odm2/models/provenance.py
@@ -1,32 +1,30 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Provenance schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Provenance.html
 """
 
-class AuthorLists(_model_base):
+class AuthorLists():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_AuthorLists.html"""
 
-class Citations(_model_base):
+class Citations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_Citations.html"""
 
-class DataSetCitations(_model_base):
+class DataSetCitations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_DatasetCitations.html"""
 
-class DerivationEquations(_model_base):
+class DerivationEquations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_DerivationEquations.html"""
 
-class MethodCitations(_model_base):
+class MethodCitations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_MethodCitations.html"""
 	
-class RelatedAnnotations(_model_base):
+class RelatedAnnotations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_RelatedAnnotations.html"""
 
-class RelatedDatasets(_model_base):
+class RelatedDatasets():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_RelatedDatasets.html"""
 
-class RelatedResults(_model_base):
+class RelatedResults():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_RelatedResults.html"""
 
-class ResultDerivationEquations(_model_base):
+class ResultDerivationEquations():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Provenance_ResultDerivationEquations.html"""

--- a/src/odm2/models/results.py
+++ b/src/odm2/models/results.py
@@ -1,59 +1,57 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Results schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Results.html
 """
 
-class CategoricalResults (_model_base):
+class CategoricalResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_CategoricalResults.html"""
 
-class CategoricalResultValues (_model_base):
+class CategoricalResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_CategoricalResultValues.html"""
 
-class MeasurementResults (_model_base):
+class MeasurementResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_MeasurementResults.html"""
 
-class MeasurementResultValues (_model_base):
+class MeasurementResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_MeasurementResultValues.html"""
 
-class PointCoverageResults (_model_base):
+class PointCoverageResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_PointCoverageResults.html"""
 
-class PointCoverageResultValues (_model_base):
+class PointCoverageResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_PointCoverageResultValues.html"""
 
-class ProfileResults (_model_base):
+class ProfileResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_ProfileResults.html"""
 
-class ProfileResultValues (_model_base):
+class ProfileResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_ProfileResultValues.html"""
 
-class SectionResults (_model_base):
+class SectionResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_SectionResults.html"""
 
-class SectionResultValues (_model_base):
+class SectionResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_SectionResultValues.html"""
 
-class SpectraResults (_model_base):
+class SpectraResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_SpectraResults.html"""
 
-class SpectraResultValues (_model_base):
+class SpectraResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_SpectraResultValues.html"""
 
-class TimeSeriesResults (_model_base):
+class TimeSeriesResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResults.html"""
 
-class TimeSeriesResultValues (_model_base):
+class TimeSeriesResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResultValues.html"""
 
-class TrajectoryResults (_model_base):
+class TrajectoryResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TrajectoryResults.html"""
 
-class TrajectoryResultValues (_model_base):
+class TrajectoryResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TrajectoryResultValues.html"""
 
-class TransectResults (_model_base):
+class TransectResults ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TransectResults.html"""
 
-class TransectResultValues (_model_base):
+class TransectResultValues ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TransectResultValues.html"""

--- a/src/odm2/models/samplingfeatures.py
+++ b/src/odm2/models/samplingfeatures.py
@@ -1,23 +1,21 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2SamplingFeatures schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2SamplingFeatures.html
 """
 
-class RelatedFeatures (_model_base):
+class RelatedFeatures ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_RelatedFeatures.html"""
 
-class Sites (_model_base):
+class Sites ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_Sites.html"""
 
-class SpatialOffsets (_model_base):
+class SpatialOffsets ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_SpatialOffsets.html"""
 
-class SpatialReferences (_model_base):
+class SpatialReferences ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_SpatialReferences.html"""
 
-class Specimens (_model_base):
+class Specimens ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_Specimens.html"""
 
-class SpecimenTaxonomicClassifiers (_model_base):
+class SpecimenTaxonomicClassifiers ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2SamplingFeatures_SpecimenTaxonomicClassifiers.html"""

--- a/src/odm2/models/simulation.py
+++ b/src/odm2/models/simulation.py
@@ -1,17 +1,15 @@
-from odm2.base import _model_base
-
 """Data models corresponding to the tables under the ODM2Simulation schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Simulation.html
 """
 
-class ModelAffiliations (_model_base):
+class ModelAffiliations ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Simulation_ModelAffiliations.html"""
 
-class Models (_model_base):
+class Models ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Simulation_Models.html"""
 
-class RelatedModels (_model_base):
+class RelatedModels ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Simulation_RelatedModels.html"""
 
-class Simulations (_model_base):
+class Simulations ():
 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Simulation_Simulations.html"""


### PR DESCRIPTION
@aufdenkampe @htaolimno @shannarucker 
This PR implements the [auxiliary functions](https://github.com/ODM2/ODM2DataSharingPortal/blob/51863842612026b78836311ec1799baedd97cc9c/src/odm2/base.py#L75-L185) into the ODM2 data models. To the extend possible we want to leverage these data models in the work for [release v0.14.0](https://github.com/ODM2/ODM2DataSharingPortal/milestone/20) so as to reduce the refactoring required and provide a smoother transition to ODM2.1. 