### PR TITLE
Fix log-on for existing users results in error page

### DIFF
--- a/src/odm2/base.py
+++ b/src/odm2/base.py
@@ -179,6 +179,7 @@ class ODM2Engine:
             if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
             obj.update_from_dict(data)
             session.commit()
+            data[pkey_name] = pkey  
 
     def delete_object(self, model:Type[Base], pkey:Union[int, str]) -> None:
         with self.session_maker() as session:


### PR DESCRIPTION
Reference Issue #635 

This PR addresses an issue in the Cognito implementation which resulted in an error page being displayed to existing users on their first log-in.

