### PR TITLE
Restore TimeseriesResult and TimeseriesResultValues ORM Models

### DIFF
--- a/src/odm2/base.py
+++ b/src/odm2/base.py
@@ -1,6 +1,6 @@
 import sqlalchemy
 from sqlalchemy.sql.expression import Select
-from sqlalchemy.orm import Query    
+from sqlalchemy.orm import Query
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.ext.declarative import declared_attr, declarative_base
 
@@ -25,104 +25,116 @@ from .models import samplingfeatures
 from .models import simulation
 from .models import auth
 
-OUTPUT_FORMATS = ('json', 'dataframe', 'dict','records')
+OUTPUT_FORMATS = ("json", "dataframe", "dict", "records")
 
-class Base():
-    
+
+class Base:
     @declared_attr
     def __tablename__(self) -> str:
         cls_name = str(self.__name__)
         return cls_name.lower()
 
     @classmethod
-    def from_dict(cls, attributes_dict:Dict) -> object:
+    def from_dict(cls, attributes_dict: Dict) -> object:
         """Alternative constructor that uses dictionary to populate attributes"""
         instance = cls.__new__(cls)
         instance.__init__()
         for key, value in attributes_dict.items():
             if hasattr(instance, key):
-                if value == '': value = None
+                if value == "":
+                    value = None
                 setattr(instance, key, value)
         return instance
 
-    def to_dict(self) -> Dict[str,Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """Converts attributes into a dictionary"""
         columns = self.__table__.columns.keys()
         output_dict = {}
         for column in columns:
-            output_dict[column] = getattr(self,column)
+            output_dict[column] = getattr(self, column)
         return output_dict
-    
-    def update_from_dict(self, attributes_dict:Dict[str, any]) -> None:
+
+    def update_from_dict(self, attributes_dict: Dict[str, any]) -> None:
         """Updates instance attributes based on provided dictionary"""
         for key, value in attributes_dict.items():
             if hasattr(self, key):
-                if value == '': value = None
+                if value == "":
+                    value = None
                 setattr(self, key, value)
 
     @classmethod
-    def get_pkey_name(cls) -> Union[str,None]:
-        """ Returns the primary key field name for a given model"""
+    def get_pkey_name(cls) -> Union[str, None]:
+        """Returns the primary key field name for a given model"""
         columns = cls.__table__.columns
         for column in columns:
-            if column.primary_key: return column.name 
+            if column.primary_key:
+                return column.name
         return None
 
-class ODM2Engine:
 
-    def __init__(self, session_maker:sqlalchemy.orm.sessionmaker, engine:sqlalchemy.engine.Engine) -> None:
+class ODM2Engine:
+    def __init__(
+        self,
+        session_maker: sqlalchemy.orm.sessionmaker,
+        engine: sqlalchemy.engine.Engine,
+    ) -> None:
         self.session_maker = session_maker
         self.engine = engine
 
-    def read_query(self, 
-            query: Union[Query, Select],
-            output_format:str='json',
-            orient:str='records') -> Union[str, pd.DataFrame]:
-
+    def read_query(
+        self,
+        query: Union[Query, Select],
+        output_format: str = "json",
+        orient: str = "records",
+    ) -> Union[str, pd.DataFrame]:
         # guard against invalid output_format strings
         if output_format not in OUTPUT_FORMATS:
-            raise ValueError(f':argument output_format={output_format}, is not a valid output_format strings: {OUTPUT_FORMATS}')
-        
+            raise ValueError(
+                f":argument output_format={output_format}, is not a valid output_format strings: {OUTPUT_FORMATS}"
+            )
+
         # use SQLAlchemy session to read_query and return response in the designated output_format
         with self.session_maker() as session:
             if isinstance(query, Select):
                 df = pd.read_sql(query, session.bind)
             else:
                 df = pd.read_sql(query.statement, session.bind)
-            
-            if output_format == 'json':
+
+            if output_format == "json":
                 return df.to_json(orient=orient)
-            elif output_format == 'dataframe':
+            elif output_format == "dataframe":
                 return df
-            elif output_format == 'dict':
+            elif output_format == "dict":
                 return df.to_dict(orient=orient)
-            elif output_format == 'records':
+            elif output_format == "records":
                 return df.to_records(index=False)
             raise TypeError("Unknown output format")
 
-    def insert_query(self, objs:List[object]) -> None:
+    def insert_query(self, objs: List[object]) -> None:
         with self.session_maker() as session:
             session.add_all(objs)
             session.commit()
 
-    def create_object(self, obj:object, preserve_pkey:bool=False) -> Union[int, str]:
-        """ Accepts an ORM mapped model and created a corresponding database record
+    def create_object(
+        self, obj: object, preserve_pkey: bool = False
+    ) -> Union[int, str]:
+        """Accepts an ORM mapped model and created a corresponding database record
 
-        Accepts on one of the ORM mapped models and creates the corresponding database 
+        Accepts on one of the ORM mapped models and creates the corresponding database
         record, returning the primary key of the newly created record.
 
         Arguments:
             obj:object - The ORM mapped model
-            preserve_pkey:bool - Default=False - flag indicating if the primary key for 
-                the object should be preserved. Avoid in general use cases where database has 
+            preserve_pkey:bool - Default=False - flag indicating if the primary key for
+                the object should be preserved. Avoid in general use cases where database has
                 a serial that auto assigned primary key, however this can be set to True to
-                specify you own the primary key value.  
+                specify you own the primary key value.
 
         Returns:
-            primary key: Union[int, str]        
+            primary key: Union[int, str]
 
         """
-        
+
         pkey_name = obj.get_pkey_name()
         if not preserve_pkey:
             setattr(obj, pkey_name, None)
@@ -133,14 +145,20 @@ class ODM2Engine:
             pkey_value = getattr(obj, pkey_name)
             return pkey_value
 
-    def read_object(self, model:Type[Base], pkey:Union[int, str], 
-            output_format:str='dict', 
-            orient:str='records') -> Dict[str, Any]:
-
+    def read_object(
+        self,
+        model: Type[Base],
+        pkey: Union[int, str],
+        output_format: str = "dict",
+        orient: str = "records",
+    ) -> Dict[str, Any]:
         with self.session_maker() as session:
             obj = session.get(model, pkey)
             pkey_name = model.get_pkey_name()
-            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            if obj is None:
+                raise ObjectNotFound(
+                    f"No '{model.__name__}' object found with {pkey_name} = {pkey}"
+                )
             session.commit()
 
             # convert obj_dict to a dictionary if it isn't one already
@@ -148,9 +166,11 @@ class ODM2Engine:
 
             # guard against invalid output_format strings
             if output_format not in OUTPUT_FORMATS:
-                raise ValueError(f':param output_format = {output_format}, which is not one of the following valid output_format strings: {OUTPUT_FORMATS}')
+                raise ValueError(
+                    f":param output_format = {output_format}, which is not one of the following valid output_format strings: {OUTPUT_FORMATS}"
+                )
 
-            if output_format == 'dict':
+            if output_format == "dict":
                 return obj_dict
 
             else:
@@ -162,13 +182,15 @@ class ODM2Engine:
                         obj_dict[key] = new_value
 
                 obj_df = pd.DataFrame.from_dict(obj_dict)
-                if output_format == 'dataframe':
+                if output_format == "dataframe":
                     return obj_df
-                elif output_format == 'json':
+                elif output_format == "json":
                     return obj_df.to_json(orient=orient)
                 raise TypeError("Unknown output format")
 
-    def update_object(self, model:Type[Base], pkey:Union[int,str], data:Dict[str, Any]) -> None:
+    def update_object(
+        self, model: Type[Base], pkey: Union[int, str], data: Dict[str, Any]
+    ) -> None:
         if not isinstance(data, dict):
             data = data.dict()
         pkey_name = model.get_pkey_name()
@@ -176,59 +198,70 @@ class ODM2Engine:
             data.pop(pkey_name)
         with self.session_maker() as session:
             obj = session.get(model, pkey)
-            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            if obj is None:
+                raise ObjectNotFound(
+                    f"No '{model.__name__}' object found with {pkey_name} = {pkey}"
+                )
             obj.update_from_dict(data)
             session.commit()
-            data[pkey_name] = pkey  
+            data[pkey_name] = pkey
 
-    def delete_object(self, model:Type[Base], pkey:Union[int, str]) -> None:
+    def delete_object(self, model: Type[Base], pkey: Union[int, str]) -> None:
         with self.session_maker() as session:
             obj = session.get(model, pkey)
             pkey_name = model.get_pkey_name()
-            if obj is None: raise ObjectNotFound(f"No '{model.__name__}' object found with {pkey_name} = {pkey}")
+            if obj is None:
+                raise ObjectNotFound(
+                    f"No '{model.__name__}' object found with {pkey_name} = {pkey}"
+                )
             session.delete(obj)
             session.commit()
 
-class Models:
 
+class Models:
     def __init__(self, base_model) -> None:
         self._base_model = base_model
-        self._process_schema(annotations)        
-        self._process_schema(core)        
-        self._process_schema(cv)        
-        self._process_schema(dataquality)        
-        self._process_schema(equipment)        
-        self._process_schema(extensionproperties)        
-        self._process_schema(externalidentifiers)        
-        self._process_schema(labanalyses)        
-        self._process_schema(provenance)        
-        self._process_schema(results)        
-        self._process_schema(samplingfeatures)        
-        self._process_schema(simulation)         
-        self._process_schema(auth)         
 
-    def _process_schema(self, schema:str) -> None:
-        classes = [c for c in dir(schema) if not c.startswith('__')]
+        self._process_schema(annotations)
+        self._process_schema(core)
+        self._process_schema(cv)
+        self._process_schema(dataquality)
+        self._process_schema(equipment)
+        self._process_schema(extensionproperties)
+        self._process_schema(externalidentifiers)
+        self._process_schema(labanalyses)
+        self._process_schema(provenance)
+        self._process_schema(results)
+        self._process_schema(samplingfeatures)
+        self._process_schema(simulation)
+        self._process_schema(auth)
+
+    def _process_schema(self, schema: str) -> None:
+        classes = [c for c in dir(schema) if not c.startswith("__")]
         base = tuple([self._base_model])
         for class_name in classes:
             model = getattr(schema, class_name)
-            model_attribs = self._trim_dunders(dict(model.__dict__.copy())) 
-            extended_model =  type(class_name, base, model_attribs) 
+            # ignore modules for when a schema imports them
+            if type(model) is not type:
+                continue
+
+            extended_model = type(class_name, base, {})
             setattr(self, class_name, extended_model)
 
-    def _trim_dunders(self, dictionary:Dict[str, Any]) -> Dict[str, Any]:
-        return { k:v for k, v in dictionary.items() if not k.startswith('__') } 
+    def _trim_dunders(self, dictionary: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: v for k, v in dictionary.items() if not k.startswith("__")}
 
-class ODM2DataModels():
 
-    def __init__(self, engine:sqlalchemy.engine, schema:str='odm2', cache_path:str=None) -> None:
-
+class ODM2DataModels:
+    def __init__(
+        self, engine: sqlalchemy.engine, schema: str = "odm2", cache_path: str = None
+    ) -> None:
         self._schema = schema
         self._cache_path = cache_path
 
         self._engine = engine
         self._session = sqlalchemy.orm.sessionmaker(self._engine)
-        self._cached= False
+        self._cached = False
         self.odm2_engine: ODM2Engine = ODM2Engine(self._session, self._engine)
 
         self._model_base = self._prepare_model_base()
@@ -238,20 +271,36 @@ class ODM2DataModels():
 
     def _prepare_model_base(self):
         try:
-            with open(self._cache_path, 'rb') as file:
+            with open(self._cache_path, "rb") as file:
                 metadata = pickle.load(file=file)
                 self._cached = True
                 return declarative_base(cls=Base, bind=self._engine, metadata=metadata)
-        except FileNotFoundError: 
+        except FileNotFoundError:
             metadata = sqlalchemy.MetaData(schema=self._schema)
             self._cached = False
             return automap_base(cls=Base, metadata=metadata)
 
     def _prepare_automap_models(self):
+        # models that are declaratively mapped.
+        setattr(
+            self._model_base,
+            "TimeSeriesResults",
+            dict(results.TimeSeriesResults.__dict__),
+        )
+        setattr(
+            self._model_base,
+            "TimeSeriesResultValues",
+            dict(results.TimeSeriesResultValues.__dict__),
+        )
+
         self._model_base.prepare(self._engine)
-        if not self._cache_path: return
+        if not self._cache_path:
+            return
         try:
-            with open(self._cache_path, 'wb') as file:
+            with open(self._cache_path, "wb") as file:
                 pickle.dump(self._model_base.metadata, file)
         except FileNotFoundError:
-            warnings.warn('Unable to cache models which may lead to degraded performance.', RuntimeWarning)
+            warnings.warn(
+                "Unable to cache models which may lead to degraded performance.",
+                RuntimeWarning,
+            )

--- a/src/odm2/models/results.py
+++ b/src/odm2/models/results.py
@@ -1,6 +1,12 @@
 """Data models corresponding to the tables under the ODM2Results schema
 	Reference: http://odm2.github.io/ODM2/schemas/ODM2_Current/schemas/ODM2Results.html
 """
+import typing
+import datetime
+
+import sqlalchemy as sqla
+from sqlalchemy import orm
+from sqlalchemy.dialects import postgresql as pg
 
 
 class CategoricalResults:
@@ -51,11 +57,68 @@ class SpectraResultValues:
     """http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_SpectraResultValues.html"""
 
 
-# class TimeSeriesResults ():
-# 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResults.html"""
+class TimeSeriesResults:
+    """http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResults.html"""
 
-# class TimeSeriesResultValues ():
-# 	"""http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResultValues.html"""
+    resultid: orm.Mapped[int] = sqla.Column("resultid", sqla.Integer, primary_key=True)
+    xlocation: orm.Mapped[typing.Optional[float]] = sqla.Column(
+        "xlocation", pg.DOUBLE_PRECISION
+    )
+    xlocationunitid: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "xlocationunitid", sqla.ForeignKey("units.unitsid")
+    )
+    ylocation: orm.Mapped[typing.Optional[float]] = sqla.Column(
+        "ylocation", pg.DOUBLE_PRECISION
+    )
+    ylocationunitid: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "ylocationunitid", sqla.ForeignKey("units.unitsid")
+    )
+    zlocation: orm.Mapped[typing.Optional[float]] = sqla.Column(
+        "zlocation", pg.DOUBLE_PRECISION
+    )
+    zlocationunitid: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "zlocationunitid", sqla.ForeignKey("units.unitsid")
+    )
+    spatialreferenceid: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "spatialreferenceid", sqla.Integer
+    )
+    intendedtimespacing: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "intendedtimespacing", pg.DOUBLE_PRECISION
+    )
+    intendedtimespacingunitid: orm.Mapped[typing.Optional[int]] = sqla.Column(
+        "intendedtimespacingunitid", sqla.ForeignKey("units.unitsid")
+    )
+    aggregationstaticcv: orm.Mapped[str] = sqla.Column(
+        "aggregationstaticcv", sqla.ForeignKey("cv_aggregationstatistic.term")
+    )
+
+
+class TimeSeriesResultValues:
+    """http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResultValues.html"""
+
+    valueid: orm.Mapped[int] = sqla.Column("valueid", sqla.Integer, primary_key=True)
+    resultid: orm.Mapped[int] = sqla.Column(
+        "resultid", sqla.ForeignKey("results.resultid")
+    )
+    datavalue: orm.Mapped[float] = sqla.Column("datavalue", pg.DOUBLE_PRECISION)
+    valuedatetime: orm.Mapped[datetime.datetime] = sqla.Column(
+        "valuedatetime", sqla.DateTime
+    )
+    valuedatetimeutcoffset: orm.Mapped[int] = sqla.Column(
+        "valuedatetimeutcoffset", sqla.Integer
+    )
+    censorcodecv: orm.Mapped[str] = sqla.Column(
+        "censorcodecv", sqla.ForeignKey("cv_censorcode.term")
+    )
+    qualitycodecv: orm.Mapped[str] = sqla.Column(
+        "qualitycodecv", sqla.ForeignKey("cv_qualitycode.term")
+    )
+    timeaggregationinterval: orm.Mapped[float] = sqla.Column(
+        "timeaggregationinterval", pg.DOUBLE_PRECISION
+    )
+    timeaggregationintervalunitsid: orm.Mapped[int] = sqla.Column(
+        "timeaggregationintervalunitsid", sqla.ForeignKey("units.unitsid")
+    )
 
 
 class TrajectoryResults:


### PR DESCRIPTION
I had disabled these models during some investigation into Leafpack issues because the ORM didn't handle the missing primary key field. However, I forgot to reenable these, which breaks tons of other features on the site. This PR restores this data models, but I also declaratively maps these models so that automapper does not handle these. This lets us get around some restrictions related to TimescaleDB.