### PR TITLE
Organization seeding for users

### DIFF
--- a/src/accounts/user.py
+++ b/src/accounts/user.py
@@ -9,6 +9,7 @@ import dataloader
 from accounts.cognito_updater import CognitoUpdater
 import odm2
 from odm2 import odm2datamodels
+from odm2 import crud
 
 models = odm2datamodels.models
 odm2_engine = odm2datamodels.odm2_engine
@@ -45,6 +46,7 @@ class ODM2User(User):
             odm2_engine.update_object(models.Accounts, user["accountid"], user)
             return cls.from_userid(user["accountid"])
 
+        #create the account record for the user
         user = models.Accounts()
         user.cognitoid = mapping["sub"]
         user.username = mapping["preferred_username"]
@@ -55,12 +57,8 @@ class ODM2User(User):
         user.issiteadmin = False
         pkey = odm2_engine.create_object(user)
 
-        # create affiliation record
-        affiliation = models.Affiliations()
-        affiliation.affiliationstartdate = datetime.datetime.now()
-        affiliation.primaryemail = mapping["email"]
-        affiliation.accountid = pkey
-        odm2_engine.create_object(affiliation)
+        #create organization and affiliation
+        crud.organization.create_individual_organization(account=user)
 
         return cls.from_userid(userid=pkey)
 

--- a/src/odm2/crud/__init__.py
+++ b/src/odm2/crud/__init__.py
@@ -1,0 +1,2 @@
+import odm2.crud.organization
+import odm2.crud.users

--- a/src/odm2/crud/organization.py
+++ b/src/odm2/crud/organization.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from typing import List, Optional, Tuple
 from sqlalchemy.orm import Session
 
@@ -5,6 +7,32 @@ from odm2 import odm2datamodels
 
 models = odm2datamodels.models
 session = odm2datamodels.odm2_engine.session_maker
+
+def create_individual_organization(
+    account: models.Accounts,
+    session: Session = session(),
+) -> None:
+    #create organization model
+    organization = models.Organizations()
+    organization.organizationtypecv = 'Individual'
+    organization.organizationcode = f'individual_org_account_{account.accountid}'
+    organization.organizationname = f'individual_org_account_{account.accountid}'
+
+    #create organization record
+    session.add(organization)
+    session.commit()
+    
+    #make affiliation record to tie new organization to account
+    affiliation = models.Affiliations()
+    affiliation.organizationid=organization.organizationid
+    affiliation.isprimaryorganizationcontact=True
+    affiliation.affiliationstartdate = datetime.today()
+    affiliation.primaryemail = account.accountemail
+    affiliation.accountid = account.accountid
+
+    #add record to database
+    session.add(affiliation)
+    session.commit()
 
 def read_organization_names(
     session: Session = session(), 

--- a/src/odm2/models/__init__.py
+++ b/src/odm2/models/__init__.py
@@ -1,0 +1,1 @@
+import odm2.models.base

--- a/src/odm2/models/base.py
+++ b/src/odm2/models/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/src/odm2/models/results.py
+++ b/src/odm2/models/results.py
@@ -4,10 +4,7 @@ import datetime
 from sqlalchemy import orm
 import sqlalchemy as sqla
 from sqlalchemy.dialects import postgresql as pg
-from sqlalchemy.orm import declarative_base
-
-Base = declarative_base()
-
+from odm2.models.base import Base
 
 class TimeSeriesResults(Base):
     """http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResults.html"""
@@ -46,7 +43,6 @@ class TimeSeriesResults(Base):
     aggregationstaticcv: orm.Mapped[str] = sqla.Column(
         "aggregationstaticcv", sqla.ForeignKey("cv_aggregationstatistic.term")
     )
-
 
 class TimeSeriesResultValues(Base):
     """http://odm2.github.io/ODM2/schemas/ODM2_Current/tables/ODM2Results_TimeSeriesResultValues.html"""


### PR DESCRIPTION
Related issue #708 
The code was not updates to automatically generate an organization for new users. With release 0.17, organization are site owners. The effect was new users would not have full feature set available to them and lots of rendering issues. This addresses that by adding additional code to seed a new user logging with an individual organization affiliated with there account. 