### PR TITLE
Update help link

### DIFF
--- a/src/dataloaderinterface/templates/dataloaderinterface/base.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/base.html
@@ -92,7 +92,7 @@
 
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link" href="https://wikiwatershed.org/help/" target="_blank">Help <i
+                        <a class="nav-link" href="https://wikiwatershed.org/help/monitor-help/" target="_blank">Help <i
                                 class="material-icons" style="font-size: 14px;">open_in_new</i></a>
                     </li>
                     <li class="nav-item">


### PR DESCRIPTION
Related issues: #726
Updates the nav bar `help` link to point to new consolidated page. Issuing a PR to deploy this update as hot fix and get updated help documentation live prior to the next release [0.18](https://github.com/ODM2/ODM2DataSharingPortal/milestone/32). 