### PR TITLE
Readd Google Analytics Code

### DIFF
--- a/src/dataloaderinterface/templates/dataloaderinterface/base.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/base.html
@@ -42,6 +42,19 @@
 
     {% endblock %}
 
+    {% block google_analytics %}
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-W3HB190PJJ"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-W3HB190PJJ');
+        </script>
+    {% endblock google_analytics %}
+
+
 </head>
 
 <body>


### PR DESCRIPTION
Reference #700
In issue 700 we removed an outdated goggle analytics code. However, we still want to have google analytics tracking to better inform decision, support grant writing, etc. This commit adds back in an active GA code.