### PR TITLE
Address 0's treated as nulls

### DIFF
--- a/src/dataloaderinterface/templates/dataloaderinterface/site_details.html
+++ b/src/dataloaderinterface/templates/dataloaderinterface/site_details.html
@@ -402,7 +402,7 @@
                                                     <span class="last-observation">{{ sensor.last_measurement.value_local_datetime|default:"-" }} {{ sensor.last_measurement.utc_offset_hours_display }}</span>
                                                 </div>
                                                 <div class="text-right">
-                                                    <h3 style="margin: 0; color: steelblue;">{{ sensor.last_measurement.data_value|roundfloat:4|default:" - " }}</h3>
+                                                    <h3 style="margin: 0; color: steelblue;">{{ sensor.last_measurement.data_value|roundfloat:4|default_if_none:" - " }}</h3>
                                                     <h6 style="margin-top: 0;" class="unit">
                                                         ({{ sensor.sensor_output.unit_abbreviation }})</h6>
                                                 </div>


### PR DESCRIPTION
#757
The 'default' tag helper used in the Django templates provides a mechanism to populate a default value when the expression evaluates to false. However this mechanism checks for falsy behavior, which in python means that False, 0, None, empty list ([]) will all evaluate to False. This switches to the `default_if_none` tag helper, which only evaluates false when None is provided.